### PR TITLE
Avoid transition to a new page on javascript links click.

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,9 +29,9 @@
   </div>
 
   <div id="options">
-    <p>Click to: <span id="use_random"><a href="javascript:GIGO.use_random();1;">use random addresses</a></span> |
-    <span id="use_cacheable"><a href="javascript:GIGO.use_cacheable();1;">use cacheable addresses</a></span> |
-    <span id="use_stop"><a href="javascript:GIGO.use_stop();1;">stop</a></span></p>
+    <p>Click to: <span id="use_random"><a href="javascript:GIGO.use_random()">use random addresses</a></span> |
+    <span id="use_cacheable"><a href="javascript:GIGO.use_cacheable()">use cacheable addresses</a></span> |
+    <span id="use_stop"><a href="javascript:GIGO.use_stop()">stop</a></span></p>
   </div>
 
   <div id="content">


### PR DESCRIPTION
The trailing "1" was making the browsers unhappy - they were transitioning to an empty page just containing "1". With the attached diff they no longer do that. Tested in FF, Chrome, Safari  - all on OSX 10.9.
